### PR TITLE
Fix compile error with GHC 7.2.*

### DIFF
--- a/Data/Void/Unsafe.hs
+++ b/Data/Void/Unsafe.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-#if !defined(SAFE) && defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 702
+#if !defined(SAFE) && defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 704
 #define UNSAFE
 {-# LANGUAGE Unsafe #-}
 #endif


### PR DESCRIPTION
While the Safe Haskell extension was introduced in GHC 7.2, -XUnsafe
extension was introduced in 7.4.

http://www.haskell.org/ghc/docs/7.2.2/html/users_guide/safe-haskell.html#safe-flag-summary
http://www.haskell.org/ghc/docs/7.4.1/html/users_guide/safe-haskell.html#safe-flag-summary
