### PR TITLE
Backport NFData instance

### DIFF
--- a/src-old/Data/Void.hs
+++ b/src-old/Data/Void.hs
@@ -32,6 +32,7 @@ module Data.Void
   , vacuousM
   ) where
 
+import Control.DeepSeq (NFData(..))
 import Control.Monad (liftM)
 import Data.Ix
 import Data.Hashable
@@ -109,3 +110,7 @@ instance Ix Void where
 #if MIN_VERSION_base(4,0,0)
 instance Exception Void
 #endif
+
+-- | Defined as @'rnf' = 'absurd'@.
+instance NFData Void where
+  rnf = absurd

--- a/void.cabal
+++ b/void.cabal
@@ -41,7 +41,8 @@ library
     exposed-modules: Data.Void
 
   build-depends:
-    base       >= 3 && < 10,
+    base       >= 3   && < 10,
+    deepseq    >= 1.1 && < 1.5,
     hashable   >= 1.1,
     semigroups >= 0.8.2
 


### PR DESCRIPTION
`deepseq` defines an `NFData Void` instance, but it's only available on GHC 7.10 and later. This makes me sad.