### PR TITLE
Only depend on deepseq, hashable, and semigroups if using GHC 7.8 or earlier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,108 @@
-language: haskell
+# This file has been generated -- see https://github.com/hvr/multi-ghc-travis
+language: c
+sudo: false
+
+notifications:
+  irc:
+    channels:
+      - "irc.freenode.org#haskell-lens"
+    skip_join: true
+    template:
+      - "\x0313void\x03/\x0306%{branch}\x03 \x0314%{commit}\x03 %{build_url} %{message}"
+
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.18 GHCVER=7.0.4
+      compiler: ": #GHC 7.0.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.0.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.2.2
+      compiler: ": #GHC 7.2.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.2.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.4.2
+      compiler: ": #GHC 7.4.2"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.4.2], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.6.3
+      compiler: ": #GHC 7.6.3"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.6.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.18 GHCVER=7.8.4
+      compiler: ": #GHC 7.8.4"
+      addons: {apt: {packages: [cabal-install-1.18,ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      compiler: ": #GHC 7.10.3"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3], sources: [hvr-ghc]}}
+    - env: CABALVER=1.24 GHCVER=8.0.2
+      compiler: ": #GHC 8.0.2"
+      addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.2], sources: [hvr-ghc]}}
+    - env: CABALVER=head GHCVER=head
+      compiler: ": #GHC head"
+      addons: {apt: {packages: [cabal-install-head,ghc-head], sources: [hvr-ghc]}}
+
+  allow_failures:
+    - env: CABALVER=head GHCVER=head
+
+before_install:
+ - unset CC
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+
+install:
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
+ - travis_retry cabal update -v
+ - sed -i 's/^jobs:/-- jobs:/' ${HOME}/.cabal/config
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install -j --only-dependencies --enable-tests --enable-benchmarks;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
+
+# Here starts the actual work to be performed for the package under test;
+# any command which exits with a non-zero exit code causes the build to fail.
+script:
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
+
+# Check that the resulting source distribution can be built & installed.
+# If there are no other `.tar.gz` files in `dist`, this can be even simpler:
+# `cabal install --force-reinstalls dist/*-*.tar.gz`
+ - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
+   (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+
+# EOF

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+0.7.2
+-----
+* Only depend on `deepseq`, `hashable`, and `semigroups` if using GHC 7.8 or earlier.
+
 0.7.1
 -----
 * Support `semigroups` 0.17 on older GHCs

--- a/void.cabal
+++ b/void.cabal
@@ -1,6 +1,6 @@
 name:          void
 category:      Data Structures
-version:       0.7.1
+version:       0.7.2
 license:       BSD3
 cabal-version: >= 1.10
 license-file:  LICENSE
@@ -36,27 +36,27 @@ library
   exposed-modules:
     Data.Void.Unsafe
 
-  if !impl(ghc>=7.9)
-    hs-source-dirs: src-old
-    exposed-modules: Data.Void
-
-  build-depends:
-    base       >= 3   && < 10,
-    deepseq    >= 1.1 && < 1.5,
-    hashable   >= 1.1,
-    semigroups >= 0.8.2
+  build-depends: base >= 3 && < 10
 
   ghc-options: -Wall
 
   if flag(safe)
     cpp-options: -DSAFE
 
-  if impl(ghc)
-    other-extensions: DeriveDataTypeable
-    cpp-options: -DLANGUAGE_DeriveDataTypeable
+  if !impl(ghc>=7.9)
+    hs-source-dirs: src-old
+    exposed-modules: Data.Void
+    build-depends:
+      deepseq    >= 1.1 && < 1.5,
+      hashable   >= 1.1,
+      semigroups >= 0.8.2
 
-  if impl(ghc >= 7.2)
-    other-extensions: StandaloneDeriving
-    -- other-extensions: DeriveGeneric isn't known to cabal yet
-    cpp-options: -DLANGUAGE_DeriveGeneric
-    build-depends: ghc-prim
+    if impl(ghc)
+      other-extensions: DeriveDataTypeable
+      cpp-options: -DLANGUAGE_DeriveDataTypeable
+
+    if impl(ghc >= 7.2)
+      other-extensions: StandaloneDeriving
+      -- other-extensions: DeriveGeneric isn't known to cabal yet
+      cpp-options: -DLANGUAGE_DeriveGeneric
+      build-depends: ghc-prim


### PR DESCRIPTION
Fixes #13.